### PR TITLE
tags images

### DIFF
--- a/hasher/Dockerfile
+++ b/hasher/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:3-alpine
 RUN apk add --update build-base curl
 RUN gem install sinatra
 RUN gem install thin

--- a/rng/Dockerfile
+++ b/rng/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3-alpine
 RUN pip install Flask
 COPY rng.py /
 CMD ["python", "rng.py"]

--- a/stacks/dockercoins/hasher/Dockerfile
+++ b/stacks/dockercoins/hasher/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:3-alpine
 RUN apk add --update build-base curl
 RUN gem install sinatra
 RUN gem install thin

--- a/stacks/dockercoins/rng/Dockerfile
+++ b/stacks/dockercoins/rng/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3-alpine
 RUN pip install Flask
 COPY rng.py /
 CMD ["python", "rng.py"]

--- a/stacks/dockercoins/worker/Dockerfile
+++ b/stacks/dockercoins/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3-alpine
 RUN pip install redis
 RUN pip install requests
 COPY worker.py /

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3-alpine
 RUN pip install redis
 RUN pip install requests
 COPY worker.py /


### PR DESCRIPTION
 - specify python major version in rng and worker
 - specify ruby and alpine version in hasher (it uses apk commands)

motivation behind it is to stay reliable over the time because we use it in docker desktop CI