### PR TITLE
dockercoins: webui: fix library/image mismatch

### DIFF
--- a/webui/Dockerfile
+++ b/webui/Dockerfile
@@ -1,7 +1,11 @@
-FROM node:4-slim
+FROM node:lts-slim
+
+# Needed for node 15+ see https://stackoverflow.com/a/65443098
+WORKDIR /usr/app
+
 RUN npm install express
 RUN npm install redis
-COPY files/ /files/
-COPY webui.js /
+COPY files/ ./files/
+COPY webui.js .
 CMD ["node", "webui.js"]
 EXPOSE 80


### PR DESCRIPTION
The latest reddis which is `npm install`ed, is not compatable with `node:4-slim`.

The error looks like:
```
dockercoins_webui_1
/node_modules/redis/dist/index.js:26
       ...options
       ^^^

SyntaxError: Unexpected token
```

Since we're installing the latest stable libraries, it probably makes sense to use the `lts-slim` image.

Note the WORKDIR needs to be set after node 15.

Signed-off-by: David Scott <dave.scott@docker.com>